### PR TITLE
Fix incorrect newline handling in Markdown conversions

### DIFF
--- a/lib/widgets/MarkdownTextInput/format_markdown.dart
+++ b/lib/widgets/MarkdownTextInput/format_markdown.dart
@@ -52,10 +52,7 @@ class FormatMarkdown {
         final splitedData = data
             .substring(lesserIndex, greaterIndex)
             .split('\n');
-        changedData = splitedData.map((value) {
-          index++;
-          return index == splitedData.length ? '* $value' : '* $value\n';
-        }).join();
+        changedData = splitedData.map((value) => '* $value').join('\n');
         replaceCursorIndex = 0;
         break;
       case MarkdownType.code:
@@ -67,10 +64,7 @@ class FormatMarkdown {
         final splitedData = data
             .substring(lesserIndex, greaterIndex)
             .split('\n');
-        changedData = splitedData.map((value) {
-          index++;
-          return index == splitedData.length ? '> $value' : '> $value\n';
-        }).join();
+        changedData = splitedData.map((value) => '> $value').join('\n');
         replaceCursorIndex = 0;
         break;
       case MarkdownType.separator:


### PR DESCRIPTION
When converting text to a Markdown list or blockquote, the previous implementation manually appended newlines to all elements except the last one before joining. This logic was flawed and could lead to inconsistent spacing. 

The fix simplifies this by mapping each element to its Markdown prefixed version and then joining them with a single newline character, ensuring correct structure for both lists and blockquotes.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.