### PR TITLE
🐛 fix horizontal scrolling support for table in home.dart #50

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -345,6 +345,12 @@ class _HomeState extends State<Home> {
                       );
                     },
                   ),
+                  TableConfig(
+                    wrapper: (tableWidget) => SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: tableWidget,
+                    ),
+                  ),
                 ],
               ),
             ),


### PR DESCRIPTION
This pull request introduces a configuration change to the `Home` screen to improve the handling of horizontally overflowing tables. The main update is the addition of a `TableConfig` widget that wraps tables in a horizontally scrollable view, ensuring better usability on smaller screens.

UI enhancement:

* Added a `TableConfig` widget that wraps tables in a `SingleChildScrollView` with horizontal scrolling, allowing tables to be viewed properly even when their width exceeds the screen size. (`lib/home.dart`)