### PR TITLE
Add 'Save As' functionality

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -22,7 +22,16 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-enum MenuItem { switchTheme, switchView, open, clear, save, saveAs, print, donate }
+enum MenuItem {
+  switchTheme,
+  switchView,
+  open,
+  clear,
+  save,
+  saveAs,
+  print,
+  donate,
+}
 
 class Home extends StatefulWidget {
   final DevicePreferenceNotifier devicePreferenceNotifier;
@@ -212,9 +221,9 @@ class _HomeState extends State<Home> {
         }
       } catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text("Error saving file: $e")),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text("Error saving file: $e")));
         }
       }
     } else {

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -22,7 +22,7 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-enum MenuItem { switchTheme, switchView, open, clear, save, print, donate }
+enum MenuItem { switchTheme, switchView, open, clear, save, saveAs, print, donate }
 
 class Home extends StatefulWidget {
   final DevicePreferenceNotifier devicePreferenceNotifier;
@@ -41,6 +41,7 @@ class _HomeState extends State<Home> {
   );
   String _filePath = "/storage/emulated/0/Download";
   String _fileName = 'Markdown';
+  bool _isOpenedFile = false;
   bool _isPreview = false;
   bool _isLoading = true;
   String _inputText = '';
@@ -120,6 +121,7 @@ class _HomeState extends State<Home> {
         final File file = File(_filePath);
         _inputText = await file.readAsString();
         _textEditingController.text = _inputText;
+        _isOpenedFile = true;
         setState(() {});
         final folderPath = _filePath.substring(
           0,
@@ -175,6 +177,9 @@ class _HomeState extends State<Home> {
               setState(() {
                 _inputText = "";
                 _textEditingController.clear();
+                _isOpenedFile = false;
+                _filePath = "/storage/emulated/0/Download";
+                _fileName = 'Markdown';
               });
               Navigator.pop(context);
             },
@@ -194,25 +199,65 @@ class _HomeState extends State<Home> {
         ),
       );
       return;
-    } else {
-      final filePath = await FilePicker.saveFile(
-        dialogTitle: AppLocalizations.of(context)!.saveFileDialogTitle,
-        fileName: (!kIsWeb && Platform.isWindows) ? null : "$_fileName.md",
-        initialDirectory:
-            widget.devicePreferenceNotifier.value.defaultFolderPath,
-        type: FileType.custom,
-        allowedExtensions: ['md'],
-        bytes: utf8.encode(_inputText),
-      );
-      if (filePath != null) {
-        final folderPath = filePath.substring(
-          0,
-          filePath.lastIndexOf(Platform.pathSeparator),
-        );
-        unawaited(
-          widget.devicePreferenceNotifier.setDefaultFolderPath(folderPath),
-        );
+    }
+
+    if (_isOpenedFile) {
+      try {
+        final file = File(_filePath);
+        await file.writeAsString(_inputText);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("File saved successfully")),
+          );
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text("Error saving file: $e")),
+          );
+        }
       }
+    } else {
+      await _saveFileAs();
+    }
+  }
+
+  Future<void> _saveFileAs() async {
+    if (_inputText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context)!.emptyInputTextContent),
+        ),
+      );
+      return;
+    }
+
+    final filePath = await FilePicker.saveFile(
+      dialogTitle: AppLocalizations.of(context)!.saveFileDialogTitle,
+      fileName: (!kIsWeb && Platform.isWindows) ? null : "$_fileName.md",
+      initialDirectory: widget.devicePreferenceNotifier.value.defaultFolderPath,
+      type: FileType.custom,
+      allowedExtensions: ['md'],
+      bytes: utf8.encode(_inputText),
+    );
+
+    if (filePath != null) {
+      setState(() {
+        _filePath = filePath;
+        _fileName = _filePath.substring(
+          _filePath.lastIndexOf(Platform.pathSeparator) + 1,
+          _filePath.lastIndexOf("."),
+        );
+        _isOpenedFile = true;
+      });
+
+      final folderPath = _filePath.substring(
+        0,
+        _filePath.lastIndexOf(Platform.pathSeparator),
+      );
+      unawaited(
+        widget.devicePreferenceNotifier.setDefaultFolderPath(folderPath),
+      );
     }
   }
 
@@ -533,6 +578,9 @@ class _HomeState extends State<Home> {
                     case MenuItem.save:
                       await _saveFile();
                       break;
+                    case MenuItem.saveAs:
+                      await _saveFileAs();
+                      break;
                     case MenuItem.clear:
                       await _clearText();
                       break;
@@ -571,6 +619,16 @@ class _HomeState extends State<Home> {
                         const Icon(Icons.save),
                         const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.save),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: MenuItem.saveAs,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.save_as),
+                        const SizedBox(width: 8),
+                        Text(AppLocalizations.of(context)!.saveAs),
                       ],
                     ),
                   ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -71,6 +71,10 @@
   "@save": {
     "description": "Positive Action for the Save File Alert Dialog and the Save File Menu Item"
   },
+  "saveAs": "Save As",
+  "@saveAs": {
+    "description": "Menu Item to save the current file with a new name or location"
+  },
   "linkDialogTextTitle": "Text",
   "@linkDialogTextTitle": {
     "description": "Text Field Title of The Link Dialog Box"

--- a/untranslated_messages.json
+++ b/untranslated_messages.json
@@ -1,1 +1,785 @@
-{}
+{
+  "ace": [
+    "saveAs"
+  ],
+
+  "ach": [
+    "saveAs"
+  ],
+
+  "af": [
+    "saveAs"
+  ],
+
+  "ak": [
+    "saveAs"
+  ],
+
+  "alz": [
+    "saveAs"
+  ],
+
+  "am": [
+    "saveAs"
+  ],
+
+  "ar": [
+    "saveAs"
+  ],
+
+  "as": [
+    "saveAs"
+  ],
+
+  "awa": [
+    "saveAs"
+  ],
+
+  "ay": [
+    "saveAs"
+  ],
+
+  "az": [
+    "saveAs"
+  ],
+
+  "bal": [
+    "saveAs"
+  ],
+
+  "ban": [
+    "saveAs"
+  ],
+
+  "bbc": [
+    "saveAs"
+  ],
+
+  "bci": [
+    "saveAs"
+  ],
+
+  "be": [
+    "saveAs"
+  ],
+
+  "bem": [
+    "saveAs"
+  ],
+
+  "ber": [
+    "saveAs"
+  ],
+
+  "bew": [
+    "saveAs"
+  ],
+
+  "bg": [
+    "saveAs"
+  ],
+
+  "bho": [
+    "saveAs"
+  ],
+
+  "bik": [
+    "saveAs"
+  ],
+
+  "bm": [
+    "saveAs"
+  ],
+
+  "bn": [
+    "saveAs"
+  ],
+
+  "bs": [
+    "saveAs"
+  ],
+
+  "bts": [
+    "saveAs"
+  ],
+
+  "btx": [
+    "saveAs"
+  ],
+
+  "bua": [
+    "saveAs"
+  ],
+
+  "ca": [
+    "saveAs"
+  ],
+
+  "ceb": [
+    "saveAs"
+  ],
+
+  "cgg": [
+    "saveAs"
+  ],
+
+  "chk": [
+    "saveAs"
+  ],
+
+  "ckb": [
+    "saveAs"
+  ],
+
+  "cnh": [
+    "saveAs"
+  ],
+
+  "co": [
+    "saveAs"
+  ],
+
+  "crh": [
+    "saveAs"
+  ],
+
+  "crs": [
+    "saveAs"
+  ],
+
+  "cs": [
+    "saveAs"
+  ],
+
+  "cy": [
+    "saveAs"
+  ],
+
+  "da": [
+    "saveAs"
+  ],
+
+  "de": [
+    "saveAs"
+  ],
+
+  "din": [
+    "saveAs"
+  ],
+
+  "doi": [
+    "saveAs"
+  ],
+
+  "dv": [
+    "saveAs"
+  ],
+
+  "dyu": [
+    "saveAs"
+  ],
+
+  "el": [
+    "saveAs"
+  ],
+
+  "eo": [
+    "saveAs"
+  ],
+
+  "es": [
+    "saveAs"
+  ],
+
+  "et": [
+    "saveAs"
+  ],
+
+  "eu": [
+    "saveAs"
+  ],
+
+  "fa": [
+    "saveAs"
+  ],
+
+  "fi": [
+    "saveAs"
+  ],
+
+  "fil": [
+    "saveAs"
+  ],
+
+  "fon": [
+    "saveAs"
+  ],
+
+  "fr": [
+    "saveAs"
+  ],
+
+  "fur": [
+    "saveAs"
+  ],
+
+  "fy": [
+    "saveAs"
+  ],
+
+  "ga": [
+    "saveAs"
+  ],
+
+  "gaa": [
+    "saveAs"
+  ],
+
+  "gd": [
+    "saveAs"
+  ],
+
+  "gl": [
+    "saveAs"
+  ],
+
+  "gn": [
+    "saveAs"
+  ],
+
+  "gom": [
+    "saveAs"
+  ],
+
+  "gu": [
+    "saveAs"
+  ],
+
+  "ha": [
+    "saveAs"
+  ],
+
+  "haw": [
+    "saveAs"
+  ],
+
+  "he": [
+    "saveAs"
+  ],
+
+  "hi": [
+    "saveAs"
+  ],
+
+  "hil": [
+    "saveAs"
+  ],
+
+  "hmn": [
+    "saveAs"
+  ],
+
+  "hr": [
+    "saveAs"
+  ],
+
+  "hrx": [
+    "saveAs"
+  ],
+
+  "ht": [
+    "saveAs"
+  ],
+
+  "hu": [
+    "saveAs"
+  ],
+
+  "hy": [
+    "saveAs"
+  ],
+
+  "iba": [
+    "saveAs"
+  ],
+
+  "id": [
+    "saveAs"
+  ],
+
+  "ig": [
+    "saveAs"
+  ],
+
+  "ilo": [
+    "saveAs"
+  ],
+
+  "is": [
+    "saveAs"
+  ],
+
+  "it": [
+    "saveAs"
+  ],
+
+  "ja": [
+    "saveAs"
+  ],
+
+  "jam": [
+    "saveAs"
+  ],
+
+  "jv": [
+    "saveAs"
+  ],
+
+  "ka": [
+    "saveAs"
+  ],
+
+  "kac": [
+    "saveAs"
+  ],
+
+  "kek": [
+    "saveAs"
+  ],
+
+  "kha": [
+    "saveAs"
+  ],
+
+  "kk": [
+    "saveAs"
+  ],
+
+  "km": [
+    "saveAs"
+  ],
+
+  "kn": [
+    "saveAs"
+  ],
+
+  "ko": [
+    "saveAs"
+  ],
+
+  "kri": [
+    "saveAs"
+  ],
+
+  "ktu": [
+    "saveAs"
+  ],
+
+  "ku": [
+    "saveAs"
+  ],
+
+  "ky": [
+    "saveAs"
+  ],
+
+  "la": [
+    "saveAs"
+  ],
+
+  "lb": [
+    "saveAs"
+  ],
+
+  "lg": [
+    "saveAs"
+  ],
+
+  "lij": [
+    "saveAs"
+  ],
+
+  "lmo": [
+    "saveAs"
+  ],
+
+  "ln": [
+    "saveAs"
+  ],
+
+  "lo": [
+    "saveAs"
+  ],
+
+  "lt": [
+    "saveAs"
+  ],
+
+  "ltg": [
+    "saveAs"
+  ],
+
+  "luo": [
+    "saveAs"
+  ],
+
+  "lus": [
+    "saveAs"
+  ],
+
+  "lv": [
+    "saveAs"
+  ],
+
+  "mai": [
+    "saveAs"
+  ],
+
+  "mak": [
+    "saveAs"
+  ],
+
+  "mam": [
+    "saveAs"
+  ],
+
+  "mfe": [
+    "saveAs"
+  ],
+
+  "mg": [
+    "saveAs"
+  ],
+
+  "mhr": [
+    "saveAs"
+  ],
+
+  "mi": [
+    "saveAs"
+  ],
+
+  "min": [
+    "saveAs"
+  ],
+
+  "mk": [
+    "saveAs"
+  ],
+
+  "ml": [
+    "saveAs"
+  ],
+
+  "mn": [
+    "saveAs"
+  ],
+
+  "mr": [
+    "saveAs"
+  ],
+
+  "ms": [
+    "saveAs"
+  ],
+
+  "mt": [
+    "saveAs"
+  ],
+
+  "mwr": [
+    "saveAs"
+  ],
+
+  "my": [
+    "saveAs"
+  ],
+
+  "ne": [
+    "saveAs"
+  ],
+
+  "new": [
+    "saveAs"
+  ],
+
+  "nhe": [
+    "saveAs"
+  ],
+
+  "nl": [
+    "saveAs"
+  ],
+
+  "no": [
+    "saveAs"
+  ],
+
+  "nso": [
+    "saveAs"
+  ],
+
+  "nus": [
+    "saveAs"
+  ],
+
+  "ny": [
+    "saveAs"
+  ],
+
+  "om": [
+    "saveAs"
+  ],
+
+  "or": [
+    "saveAs"
+  ],
+
+  "pa": [
+    "saveAs"
+  ],
+
+  "pag": [
+    "saveAs"
+  ],
+
+  "pam": [
+    "saveAs"
+  ],
+
+  "pap": [
+    "saveAs"
+  ],
+
+  "pl": [
+    "saveAs"
+  ],
+
+  "ps": [
+    "saveAs"
+  ],
+
+  "pt": [
+    "saveAs"
+  ],
+
+  "qu": [
+    "saveAs"
+  ],
+
+  "ro": [
+    "saveAs"
+  ],
+
+  "rom": [
+    "saveAs"
+  ],
+
+  "ru": [
+    "saveAs"
+  ],
+
+  "rw": [
+    "saveAs"
+  ],
+
+  "sa": [
+    "saveAs"
+  ],
+
+  "sah": [
+    "saveAs"
+  ],
+
+  "sat": [
+    "saveAs"
+  ],
+
+  "scn": [
+    "saveAs"
+  ],
+
+  "sd": [
+    "saveAs"
+  ],
+
+  "shn": [
+    "saveAs"
+  ],
+
+  "si": [
+    "saveAs"
+  ],
+
+  "sk": [
+    "saveAs"
+  ],
+
+  "sl": [
+    "saveAs"
+  ],
+
+  "sm": [
+    "saveAs"
+  ],
+
+  "sn": [
+    "saveAs"
+  ],
+
+  "so": [
+    "saveAs"
+  ],
+
+  "sq": [
+    "saveAs"
+  ],
+
+  "sr": [
+    "saveAs"
+  ],
+
+  "st": [
+    "saveAs"
+  ],
+
+  "su": [
+    "saveAs"
+  ],
+
+  "sus": [
+    "saveAs"
+  ],
+
+  "sv": [
+    "saveAs"
+  ],
+
+  "sw": [
+    "saveAs"
+  ],
+
+  "szl": [
+    "saveAs"
+  ],
+
+  "ta": [
+    "saveAs"
+  ],
+
+  "te": [
+    "saveAs"
+  ],
+
+  "tet": [
+    "saveAs"
+  ],
+
+  "tg": [
+    "saveAs"
+  ],
+
+  "th": [
+    "saveAs"
+  ],
+
+  "ti": [
+    "saveAs"
+  ],
+
+  "tiv": [
+    "saveAs"
+  ],
+
+  "tk": [
+    "saveAs"
+  ],
+
+  "tl": [
+    "saveAs"
+  ],
+
+  "tpi": [
+    "saveAs"
+  ],
+
+  "tr": [
+    "saveAs"
+  ],
+
+  "ts": [
+    "saveAs"
+  ],
+
+  "tt": [
+    "saveAs"
+  ],
+
+  "tum": [
+    "saveAs"
+  ],
+
+  "udm": [
+    "saveAs"
+  ],
+
+  "ug": [
+    "saveAs"
+  ],
+
+  "uk": [
+    "saveAs"
+  ],
+
+  "ur": [
+    "saveAs"
+  ],
+
+  "uz": [
+    "saveAs"
+  ],
+
+  "vec": [
+    "saveAs"
+  ],
+
+  "vi": [
+    "saveAs"
+  ],
+
+  "war": [
+    "saveAs"
+  ],
+
+  "xh": [
+    "saveAs"
+  ],
+
+  "yi": [
+    "saveAs"
+  ],
+
+  "yo": [
+    "saveAs"
+  ],
+
+  "yua": [
+    "saveAs"
+  ],
+
+  "yue": [
+    "saveAs"
+  ],
+
+  "zap": [
+    "saveAs"
+  ],
+
+  "zh": [
+    "saveAs"
+  ],
+
+  "zu": [
+    "saveAs"
+  ]
+}


### PR DESCRIPTION
This pull request adds a "Save As" feature to the application, allowing users to save the current file under a new name or location. It introduces a new menu item, updates the save logic to distinguish between saving an opened file and saving as a new file, and ensures the UI and localization support the new functionality.

**Feature Addition: "Save As" Functionality**
- Added a new `MenuItem.saveAs` to the `MenuItem` enum and integrated it into the menu UI, allowing users to select "Save As" from the menu. [[1]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978L25-R34) [[2]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R634-R643)
- Implemented the `_saveFileAs` method, which prompts the user to choose a file name and location, and updates state accordingly.
- Updated `_saveFile` to save directly if a file is already opened, or invoke "Save As" if not, providing user feedback on success or failure.
- Modified the menu action handler to support the new "Save As" option.

**State Management Improvements**
- Introduced `_isOpenedFile` to track whether the current file was opened from disk, and updated this state appropriately when opening, saving, or clearing files. [[1]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R53) [[2]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R133) [[3]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R189-R191) [[4]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R211-L217)

**Localization**
- Added the "Save As" string and its description to the localization file for English (`app_en.arb`).