### PR TITLE
Add sharing functionality for text, markdown, and PDF formats

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -18,9 +18,11 @@ import 'package:markdown_editor/widgets/MarkdownBody/custom_text_node.dart';
 import 'package:markdown_editor/widgets/MarkdownBody/latex_node.dart';
 import 'package:markdown_editor/widgets/MarkdownTextInput/markdown_text_input.dart';
 import 'package:markdown_widget/markdown_widget.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:printing/printing.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 enum MenuItem {
@@ -30,6 +32,7 @@ enum MenuItem {
   clear,
   save,
   saveAs,
+  share,
   print,
   donate,
 }
@@ -271,6 +274,47 @@ class _HomeState extends State<Home> {
     }
   }
 
+  Future<Uint8List> _generatePdfBytes() async {
+    final htmlFromMarkdown = md.markdownToHtml(_inputText);
+    final defaultFontFamily = GoogleFonts.notoSans().fontFamily ?? 'Roboto';
+    final printFonts = await _loadPrintFonts();
+    final pdf = pw.Document();
+    final widgets = await html2pdf.HTMLToPdf().convert(
+      htmlFromMarkdown,
+      defaultFontFamily: defaultFontFamily,
+      fontFallback: printFonts.fallbacks,
+      tagStyle: const html2pdf.HtmlTagStyle(
+        codeBlockBackgroundColor: PdfColors.grey300,
+      ),
+      fontResolver: (fontFamily, isBold, isItalic) {
+        if (fontFamily == defaultFontFamily || fontFamily == 'Noto Sans') {
+          if (isBold && isItalic) {
+            return printFonts.boldItalic;
+          } else if (isBold) {
+            return printFonts.bold;
+          } else if (isItalic) {
+            return printFonts.italic;
+          }
+          return printFonts.regular;
+        }
+        return printFonts.regular;
+      },
+    );
+    pdf.addPage(
+      pw.MultiPage(
+        theme: pw.ThemeData.withFont(
+          base: printFonts.regular,
+          bold: printFonts.bold,
+          italic: printFonts.italic,
+          boldItalic: printFonts.boldItalic,
+          fontFallback: printFonts.fallbacks,
+        ),
+        build: (context) => widgets,
+      ),
+    );
+    return pdf.save();
+  }
+
   Future<void> _printFile() async {
     if (_inputText.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -280,50 +324,72 @@ class _HomeState extends State<Home> {
       );
       return;
     } else {
-      final htmlFromMarkdown = md.markdownToHtml(_inputText);
-      final defaultFontFamily = GoogleFonts.notoSans().fontFamily ?? 'Roboto';
-      final printFonts = await _loadPrintFonts();
       await Printing.layoutPdf(
         usePrinterSettings: true,
-        onLayout: (format) async {
-          final pdf = pw.Document();
-          final widgets = await html2pdf.HTMLToPdf().convert(
-            htmlFromMarkdown,
-            defaultFontFamily: defaultFontFamily,
-            fontFallback: printFonts.fallbacks,
-            tagStyle: const html2pdf.HtmlTagStyle(
-              codeBlockBackgroundColor: PdfColors.grey300,
-            ),
-            fontResolver: (fontFamily, isBold, isItalic) {
-              if (fontFamily == defaultFontFamily ||
-                  fontFamily == 'Noto Sans') {
-                if (isBold && isItalic) {
-                  return printFonts.boldItalic;
-                } else if (isBold) {
-                  return printFonts.bold;
-                } else if (isItalic) {
-                  return printFonts.italic;
-                }
-                return printFonts.regular;
-              }
-              return printFonts.regular;
-            },
-          );
-          pdf.addPage(
-            pw.MultiPage(
-              theme: pw.ThemeData.withFont(
-                base: printFonts.regular,
-                bold: printFonts.bold,
-                italic: printFonts.italic,
-                boldItalic: printFonts.boldItalic,
-                fontFallback: printFonts.fallbacks,
-              ),
-              build: (context) => widgets,
-            ),
-          );
-          return pdf.save();
-        },
+        onLayout: (format) async => _generatePdfBytes(),
       );
+    }
+  }
+
+  Future<void> _share() async {
+    if (_inputText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context)!.emptyInputTextContent),
+        ),
+      );
+      return;
+    }
+
+    if (kIsWeb) {
+      await SharePlus.instance.share(ShareParams(text: _inputText));
+      return;
+    }
+
+    final String? format = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(AppLocalizations.of(context)!.shareAsDialogTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.text_snippet),
+              title: Text(AppLocalizations.of(context)!.plainText),
+              onTap: () => Navigator.pop(context, 'plain'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.code),
+              title: Text(AppLocalizations.of(context)!.markdown),
+              onTap: () => Navigator.pop(context, 'md'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.picture_as_pdf),
+              title: Text(AppLocalizations.of(context)!.pdf),
+              onTap: () => Navigator.pop(context, 'pdf'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (format == null) return;
+
+    if (format == 'plain') {
+      await SharePlus.instance.share(ShareParams(text: _inputText));
+    } else {
+      final tempDir = await getTemporaryDirectory();
+      final baseName = _fileName.split(Platform.pathSeparator).last;
+      if (format == 'md') {
+        final file = File('${tempDir.path}/$baseName.md');
+        await file.writeAsString(_inputText);
+        await SharePlus.instance.share(ShareParams(files: [XFile(file.path)]));
+      } else if (format == 'pdf') {
+        final bytes = await _generatePdfBytes();
+        final file = File('${tempDir.path}/$baseName.pdf');
+        await file.writeAsBytes(bytes);
+        await SharePlus.instance.share(ShareParams(files: [XFile(file.path)]));
+      }
     }
   }
 
@@ -594,6 +660,9 @@ class _HomeState extends State<Home> {
                     case MenuItem.saveAs:
                       await _saveFileAs();
                       break;
+                    case MenuItem.share:
+                      await _share();
+                      break;
                     case MenuItem.clear:
                       await _clearText();
                       break;
@@ -642,6 +711,16 @@ class _HomeState extends State<Home> {
                         const Icon(Icons.save_as),
                         const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.saveAs),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: MenuItem.share,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.share),
+                        const SizedBox(width: 8),
+                        Text(AppLocalizations.of(context)!.share),
                       ],
                     ),
                   ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -158,5 +158,25 @@
   "insert": "Insert",
   "@insert": {
     "description": "Text Action for the Insert Table Dialog"
+  },
+  "share": "Share",
+  "@share": {
+    "description": "Menu Item for Share"
+  },
+  "shareAsDialogTitle": "Share As",
+  "@shareAsDialogTitle": {
+    "description": "Title for the Share As Dialog"
+  },
+  "plainText": "Plain Text",
+  "@plainText": {
+    "description": "Option for sharing as plain text"
+  },
+  "markdown": "Markdown",
+  "@markdown": {
+    "description": "Option for sharing as markdown"
+  },
+  "pdf": "PDF",
+  "@pdf": {
+    "description": "Option for sharing as PDF"
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,14 @@ import Foundation
 
 import file_picker
 import printing
+import share_plus
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "11.0.2"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -397,6 +405,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -446,7 +462,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -629,6 +645,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -818,6 +850,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,9 +25,11 @@ dependencies:
   intl: any
   markdown: ^7.3.1
   markdown_widget: ^2.3.2+8
+  path_provider: ^2.1.5
   pdf: ^3.12.0
   permission_handler: ^12.0.1
   printing: ^5.14.3
+  share_plus: ^12.0.2
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.2
 

--- a/untranslated_messages.json
+++ b/untranslated_messages.json
@@ -1,785 +1,1765 @@
 {
   "ace": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ach": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "af": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ak": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "alz": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "am": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ar": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "as": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "awa": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ay": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "az": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bal": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ban": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bbc": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bci": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "be": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bem": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ber": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bew": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bho": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bik": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bm": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bs": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bts": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "btx": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "bua": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ca": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ceb": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "cgg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "chk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ckb": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "cnh": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "co": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "crh": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "crs": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "cs": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "cy": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "da": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "de": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "din": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "doi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "dv": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "dyu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "el": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "eo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "es": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "et": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "eu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fa": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fil": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fon": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fur": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "fy": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ga": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gaa": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gd": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gom": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "gu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ha": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "haw": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "he": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hil": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hmn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hrx": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ht": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "hy": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "iba": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "id": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ig": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ilo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "is": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "it": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ja": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "jam": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "jv": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ka": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kac": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kek": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kha": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "km": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ko": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "kri": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ktu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ku": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ky": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "la": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lb": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lij": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lmo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ln": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lt": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ltg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "luo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lus": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "lv": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mai": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mak": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mam": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mfe": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mhr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "min": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ml": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ms": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mt": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "mwr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "my": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ne": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "new": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "nhe": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "nl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "no": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "nso": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "nus": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ny": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "om": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "or": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pa": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pag": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pam": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pap": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ps": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "pt": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "qu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ro": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "rom": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ru": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "rw": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sa": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sah": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sat": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "scn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sd": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "shn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "si": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sm": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sn": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "so": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sq": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "st": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "su": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sus": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sv": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "sw": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "szl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ta": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "te": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tet": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tg": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "th": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ti": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tiv": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tl": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tpi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tr": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ts": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tt": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "tum": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "udm": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ug": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "uk": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "ur": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "uz": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "vec": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "vi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "war": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "xh": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "yi": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "yo": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "yua": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "yue": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "zap": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "zh": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ],
 
   "zu": [
-    "saveAs"
+    "saveAs",
+    "share",
+    "shareAsDialogTitle",
+    "plainText",
+    "markdown",
+    "pdf"
   ]
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <printing/printing_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -15,6 +16,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   PrintingPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PrintingPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   permission_handler_windows
   printing
+  share_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
This pull request adds a new "Share" feature to the application, allowing users to share their document as plain text, Markdown, or PDF. It introduces the `share_plus` package for cross-platform sharing, updates the UI to include a "Share" menu item, and adds the necessary localization strings. The implementation also refactors PDF generation for better code reuse and updates platform plugin registrants to support sharing on desktop platforms.

**New Feature: Share Functionality**
* Added a "Share" menu item to the UI, allowing users to share their document as plain text, Markdown, or PDF, with a dialog to select the format. [[1]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R35) [[2]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R717-R726) [[3]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R663-R665)
* Implemented the `_share` method in `_HomeState`, handling format selection, file creation, and invoking `share_plus` for sharing.

**Dependency and Platform Integration**
* Added `share_plus` and `path_provider` as dependencies in `pubspec.yaml` and imported them where necessary. [[1]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978R21-R25) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R28-R32)
* Registered `share_plus` plugins for macOS and Windows in their respective generated files to enable desktop sharing. [[1]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325R10-R17) [[2]](diffhunk://#diff-9ca3f3ddb67c9dc56635f4a7a261f461b9888c0598324eae6e6f869a4a458faeR11-R20) [[3]](diffhunk://#diff-4b55067a54dd3cd60674a36f6ce312785562c37d6eb38427e9801068b87c2297R8)

**Localization**
* Added localization strings for the new sharing feature, including menu labels and dialog options, to `app_en.arb`.

**Code Refactoring**
* Refactored PDF generation into a separate `_generatePdfBytes` method to enable reuse for both printing and sharing. [[1]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978L274-L288) [[2]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978L298-R290) [[3]](diffhunk://#diff-04b5d1882add35bc39892547239926a34a6221094d8766b25b79905b8955a978L325-R395)

Fixes #37 