### PR TITLE
Fix brightness detection and integrate dynamic color support

### DIFF
--- a/lib/device_preference_notifier.dart
+++ b/lib/device_preference_notifier.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/lib/device_preference_notifier.dart
+++ b/lib/device_preference_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum _SharedPreferencesKeys { isDarkMode, isSplitLayout, defaultFolderPath }
@@ -53,7 +54,8 @@ class DevicePreferenceNotifier extends ValueNotifier<DevicePreferences> {
     );
     final isDarkMode =
         _prefs.getBool(_SharedPreferencesKeys.isDarkMode.name) ??
-        PlatformDispatcher.instance.platformBrightness == Brightness.dark;
+        WidgetsBinding.instance.platformDispatcher.platformBrightness ==
+            Brightness.dark;
     final isSplitLayout =
         _prefs.getBool(_SharedPreferencesKeys.isSplitLayout.name) ?? true;
     final defaultFolderPath = _prefs.getString(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -29,28 +30,34 @@ class MarkdownEditorApp extends StatelessWidget {
     return ValueListenableBuilder<DevicePreferences>(
       valueListenable: devicePreferenceNotifier,
       builder: (context, devicePreference, _) {
-        return MaterialApp(
-          debugShowCheckedModeBanner: false,
-          title: 'Markdown Editor',
-          themeMode: devicePreference.isDarkMode
-              ? ThemeMode.dark
-              : ThemeMode.light,
-          theme: ThemeData(
-            useMaterial3: true,
-            textTheme: GoogleFonts.notoSansTextTheme(),
-            colorSchemeSeed: Colors.indigo,
-          ),
-          darkTheme: ThemeData(
-            useMaterial3: true,
-            textTheme: GoogleFonts.notoSansTextTheme(
-              ThemeData(brightness: Brightness.dark).textTheme,
-            ),
-            brightness: Brightness.dark,
-            colorSchemeSeed: Colors.indigo,
-          ),
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Home(devicePreferenceNotifier: devicePreferenceNotifier),
+        return DynamicColorBuilder(
+          builder: (lightDynamic, darkDynamic) {
+            return MaterialApp(
+              debugShowCheckedModeBanner: false,
+              title: 'Markdown Editor',
+              themeMode: devicePreference.isDarkMode
+                  ? ThemeMode.dark
+                  : ThemeMode.light,
+              theme: ThemeData(
+                useMaterial3: true,
+                textTheme: GoogleFonts.notoSansTextTheme(),
+                colorScheme: lightDynamic,
+                colorSchemeSeed: lightDynamic == null ? Colors.indigo : null,
+              ),
+              darkTheme: ThemeData(
+                useMaterial3: true,
+                textTheme: GoogleFonts.notoSansTextTheme(
+                  ThemeData(brightness: Brightness.dark).textTheme,
+                ),
+                brightness: Brightness.dark,
+                colorScheme: darkDynamic,
+                colorSchemeSeed: darkDynamic == null ? Colors.indigo : null,
+              ),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Home(devicePreferenceNotifier: devicePreferenceNotifier),
+            );
+          },
         );
       },
     );

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <dynamic_color/dynamic_color_plugin.h>
 #include <printing/printing_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
+  dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
   g_autoptr(FlPluginRegistrar) printing_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
   printing_plugin_register_with_registrar(printing_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  dynamic_color
   printing
   url_launcher_linux
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import dynamic_color
 import file_picker
 import printing
 import share_plus
@@ -12,6 +13,7 @@ import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   expandable:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   flutter: 3.41.6
 
 dependencies:
+  dynamic_color: ^1.8.1
   expandable: ^5.0.1
   file_picker: ^11.0.2
   flutter:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  DynamicColorPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   PrintingPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  dynamic_color
   permission_handler_windows
   printing
   share_plus


### PR DESCRIPTION
This pull request introduces dynamic color support to the application, allowing it to use system-provided color schemes when available, and falls back to a default color if not. The changes also include the necessary setup for the `dynamic_color` package across all platforms and update the theme logic in the main app.

**Dynamic color support and platform integration:**

* Added the `dynamic_color` package to `pubspec.yaml` and imported it in `main.dart` to enable dynamic color theming. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R13) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R1)
* Updated theme logic in `MarkdownEditorApp` to use dynamic color schemes (`DynamicColorBuilder`) for both light and dark themes, falling back to `Colors.indigo` when dynamic colors are unavailable. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R33-R34) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L41-R63)

**Platform-specific plugin registration:**

* Registered the `dynamic_color` plugin for Linux, macOS, and Windows by updating the respective generated plugin registrant files and CMake lists. [[1]](diffhunk://#diff-d2e4633769544500b89818cff60485a4b4e86c94c589aab76dfb2ff8ab348ae6R9-R16) [[2]](diffhunk://#diff-e976f7dc6dbdf279ea98035c3163ab7a503fb7e0cab096dd8899127422f13604R6) [[3]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325R8-R16) [[4]](diffhunk://#diff-9ca3f3ddb67c9dc56635f4a7a261f461b9888c0598324eae6e6f869a4a458faeR9-R17) [[5]](diffhunk://#diff-4b55067a54dd3cd60674a36f6ce312785562c37d6eb38427e9801068b87c2297R6)

**Minor code improvements:**

* Replaced `PlatformDispatcher.instance` with `WidgetsBinding.instance.platformDispatcher` for consistency and to avoid deprecation warnings in `device_preference_notifier.dart`. [[1]](diffhunk://#diff-0d9c31a95475946e854bcc5d18d81f35488dffc28d8ffc7183daf6084624d8fdL1-R1) [[2]](diffhunk://#diff-0d9c31a95475946e854bcc5d18d81f35488dffc28d8ffc7183daf6084624d8fdL56-R57)

Fixes #35